### PR TITLE
merge upstream

### DIFF
--- a/src/utils/notice.js
+++ b/src/utils/notice.js
@@ -55,7 +55,7 @@ async function mysNewsNotice() {
       const items = [
         "string" === typeof subject ? subject : "",
         imageCQ,
-        "string" === typeof content && content.length > 0 ? `${content} …………` : "",
+        "string" === typeof content && content.length > 90 ? `${content}……` : "",
         url,
       ];
       const stamp = post.created_at || 0;


### PR DESCRIPTION
省略号中间也不用加空格

> 标点符号用法 GB/T 15834―2011
>
> 4.11.2 形式
> 省略号的形式是“……”。
>
> 4.11.3 基本用法
> 4.11.3.1 标示引文的省略。
> 示例：我们齐声朗诵起来：“……俱往矣，数风流人物，还看今朝。”